### PR TITLE
Adding labels to the start-evaluation event

### DIFF
--- a/cloudevents.md
+++ b/cloudevents.md
@@ -593,7 +593,11 @@ The *start-evaluation* event is sent when the evaluation of a test run should be
       "type": "string"
     },
     "labels": {
-      "additionalProperties": true,
+      "patternProperties": {
+        ".*": {
+          "type": "string"
+        }
+      },
       "type": "object"
     }
   },
@@ -619,8 +623,8 @@ The *start-evaluation* event is sent when the evaluation of a test run should be
     "project": "sockshop",
     "stage": "staging",
     "service": "carts",
-    "testStrategy": "performance",
-    "deploymentStrategy": "direct",
+    "teststrategy": "performance",
+    "deploymentstrategy": "direct",
     "start": "2019-09-01 12:00:00",
     "end": "2019-09-01 12:05:00",
     "labels": {

--- a/cloudevents.md
+++ b/cloudevents.md
@@ -591,6 +591,10 @@ The *start-evaluation* event is sent when the evaluation of a test run should be
     },
     "teststrategy": {
       "type": "string"
+    },
+    "labels": {
+      "additionalProperties": true,
+      "type": "object"
     }
   },
   "additionalProperties": false,
@@ -618,7 +622,12 @@ The *start-evaluation* event is sent when the evaluation of a test run should be
     "testStrategy": "performance",
     "deploymentStrategy": "direct",
     "start": "2019-09-01 12:00:00",
-    "end": "2019-09-01 12:05:00"
+    "end": "2019-09-01 12:05:00",
+    "labels": {
+      "testid": "12345",
+      "buildnr": "build17",
+      "runby": "JohnDoe"
+    }
   }
 }
 ```

--- a/cloudevents.md
+++ b/cloudevents.md
@@ -341,6 +341,14 @@ The *configuration change* event is sent when a desired state for a service is a
         }
       },
       "type": "object"
+    },
+    "labels": {
+      "patternProperties": {
+        ".*": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "additionalProperties": false,
@@ -382,6 +390,11 @@ The *configuration change* event is sent when a desired state for a service is a
     "service": "carts",
     "valuesCanary": {
       "image": "docker.io/keptnexamples/carts:0.9.1"
+    },
+    "labels": {
+      "testid": "12345",
+      "buildnr": "build17",
+      "runby": "JohnDoe"
     }
   }
 }
@@ -434,6 +447,14 @@ The *deployment-finished* event is sent when a desired state of a service is dep
     },
     "teststrategy": {
       "type": "string"
+    },
+    "labels": {
+      "patternProperties": {
+        ".*": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "additionalProperties": false,
@@ -461,7 +482,12 @@ The *deployment-finished* event is sent when a desired state of a service is dep
     "testStrategy": "performance",
     "deploymentStrategy": "direct",
     "tag": "0.9.1",
-    "image": "docker.io/keptnexamples/carts" 
+    "image": "docker.io/keptnexamples/carts",
+    "labels": {
+      "testid": "12345",
+      "buildnr": "build17",
+      "runby": "JohnDoe"
+    }
   }
 }
 ```
@@ -513,6 +539,14 @@ The *tests-finished* event is sent when the tests for a service in a stage are f
     },
     "teststrategy": {
       "type": "string"
+    },
+    "labels": {
+      "patternProperties": {
+        ".*": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "additionalProperties": false,
@@ -540,7 +574,12 @@ The *tests-finished* event is sent when the tests for a service in a stage are f
     "testStrategy": "performance",
     "deploymentStrategy": "direct",
     "start": "2019-09-01 12:00:00",
-    "end": "2019-09-01 12:05:00"
+    "end": "2019-09-01 12:05:00",
+    "labels": {
+      "testid": "12345",
+      "buildnr": "build17",
+      "runby": "JohnDoe"
+    }
   }
 }
 ```
@@ -682,6 +721,14 @@ The *evaluation-done* event is sent when the evaluation of the test execution is
     },
     "teststrategy": {
       "type": "string"
+    },
+    "labels": {
+      "patternProperties": {
+        ".*": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "additionalProperties": false,
@@ -842,7 +889,12 @@ The *evaluation-done* event is sent when the evaluation of the test execution is
       "result":"fail",
       "service":"carts",
       "stage":"staging",
-      "teststrategy":"performance"
+      "teststrategy":"performance",
+      "labels": {
+        "testid": "12345",
+        "buildnr": "build17",
+        "runby": "JohnDoe"
+      }
    },
    "id":"1b7cd584-320e-4ef0-8522-8a817263fdab",
    "source":"lighthouse-service",
@@ -1145,6 +1197,14 @@ The *get-sli* event is sent when a SLI provider must be triggered for gathering 
     },
     "teststrategy": {
       "type": "string"
+    },
+    "labels": {
+      "patternProperties": {
+        ".*": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "additionalProperties": false,
@@ -1193,7 +1253,12 @@ The *get-sli* event is sent when a SLI provider must be triggered for gathering 
     "customFilters": [
       { "key" : "dynatraceEntityName", "value": "HealthCheckController" },
       { "key" : "tags", "value": "test-subject:true" }
-    ]
+    ],
+    "labels": {
+      "testid": "12345",
+      "buildnr": "build17",
+      "runby": "JohnDoe"
+    }
   }
 }
 ```
@@ -1246,6 +1311,14 @@ The *get-sli done* event is sent when the data gathering by a SLI provider is do
     },
     "teststrategy": {
       "type": "string"
+    },
+    "labels": {
+      "patternProperties": {
+        ".*": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "additionalProperties": false,
@@ -1307,7 +1380,12 @@ The *get-sli done* event is sent when the data gathering by a SLI provider is do
         "value": 0,
         "success": true
       }
-    ]
+    ],
+    "labels": {
+      "testid": "12345",
+      "buildnr": "build17",
+      "runby": "JohnDoe"
+    }
   }
 }
 ```


### PR DESCRIPTION
To allow users to add labels to evaluation results, e.g. for referencing Jenkins build number or other integration context information; retrieving data by using these labels should also possible.