### PR TITLE
KEP 0002 - Add result property to sh.keptn.events.tests-finished event

### DIFF
--- a/cloudevents.md
+++ b/cloudevents.md
@@ -490,7 +490,8 @@ The *tests-finished* event is sent when the tests for a service in a stage are f
     "teststrategy",
     "deploymentstrategy",
     "start",
-    "end"
+    "end",
+    "result"
   ],
   "properties": {
     "deploymentstrategy": {
@@ -512,6 +513,9 @@ The *tests-finished* event is sent when the tests for a service in a stage are f
       "type": "string"
     },
     "teststrategy": {
+      "type": "string"
+    },
+    "result": {
       "type": "string"
     }
   },
@@ -540,7 +544,8 @@ The *tests-finished* event is sent when the tests for a service in a stage are f
     "testStrategy": "performance",
     "deploymentStrategy": "direct",
     "start": "2019-09-01 12:00:00",
-    "end": "2019-09-01 12:05:00"
+    "end": "2019-09-01 12:05:00",
+    "result": "pass"
   }
 }
 ```


### PR DESCRIPTION
This spec change is based on the **KEP 0002 - Proposal for a behavioral change of the testing service**: https://github.com/keptn/enhancement-proposals/pull/2 