### PR TITLE
Make properties of a task optional

### DIFF
--- a/shipyard.md
+++ b/shipyard.md
@@ -65,7 +65,8 @@ A sequence consists of a list of tasks whereby a single task is the smallest exe
               "type": "string"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false,
@@ -162,14 +163,14 @@ A sequence consists of a list of tasks whereby a single task is the smallest exe
     },
     "Task": {
       "required": [
-        "name",
-        "properties"
+        "name"
       ],
       "properties": {
         "name": {
           "type": "string"
         },
         "properties": {
+          "type": "object",
           "additionalProperties": true
         }
       },


### PR DESCRIPTION
This PR:
* Changes the JSON schema of Shipyard to make the `properties` of a task optional and not mandatory
* Sets the type of `properties` to `object`.

The examples of a Shipyard show this correctly, but the JSON schema was wrong: 
```
    - name: hardening
      sequences:
        - name: delivery
          triggeredOn:
          - event: dev.delivery.finished
          tasks:
          - name: deployment
            properties:
              deploymentstrategy: blue_green_service
          - name: test
            properties:
              teststrategy: performance
          - name: evaluation                                         < e.g., does not have `properties` 
          - name: release
```
  

Signed-off-by: Johannes <johannes.braeuer@dynatrace.com>