### PR TITLE
keptn/keptn#4366 Add pipeline to trigger auto-update in keptn/keptn repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  send_webhook:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Trigger spec auto update in core repo
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          repository: keptn/keptn
+          event-type: spec-update
+          client-payload: '{"ref": "${GITHUB_REF}"}'


### PR DESCRIPTION
**This PR**
* adds a small GH actions workflow that sends a trigger to the keptn core repo to update the spec submodule there
* only triggers on pushed tags from this repo

Signed-off-by: Moritz Wiesinger <moritz.wiesinger@dynatrace.com>